### PR TITLE
Actually move cache to /tmp/redyt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # redyt
 Scrape Reddit images from the Terminal
 
-This shell script will automatically create the two following folders:
-  - `~/.cache/redyt`
+This shell script will automatically create the following folder:
+
   - `~/.config/redyt`
 
 Also, another file, containing the subreddits, will be created:
-    
+
   - `~/.config/redyt/subreddits.txt`
 
-It the user does not modify it, it will contain, by default, subreddit `linuxmemes`.
+If the user does not modify this file, it will contain, by default, subreddit `linuxmemes`.
 However, this default subreddit can be changed by modifying the variable `defaultsub`.
 
-However, note that you can either pass a subreddit as an argument (`./redyt [your-subreddit]`) 
+Note that you can either pass a subreddit as an argument (`./redyt [your-subreddit]`)
 or, from `dmenu`, type the name of another subreddit.
 
 Here's an example of a custom `subreddit.txt`: http://0x0.st/-rbq.txt
@@ -20,6 +20,6 @@ Here's an example of a custom `subreddit.txt`: http://0x0.st/-rbq.txt
 Please note: you will need to install the following programs:
   - dmenu (User Input)
   - jq (JSON parsing)
-  - sxiv (Image Previewing)
+  - sxiv (Image Viewing)
 
 `notify-send` is also recommended but, if not present, `echo` will be used as a notifier.

--- a/redyt
+++ b/redyt
@@ -8,7 +8,7 @@ done
 [ ! "$(which notify-send)" ] && notifier="echo" || notifier="notify-send"
 
 # Default config directory
-configdir="/tmp/redyt"
+configdir="${XDG_CONFIG_HOME:-$HOME/.config}/redyt"
 
 # Create .config/redyt if it does not exist to prevent
 # the program from not functioning properly
@@ -37,7 +37,7 @@ else
 fi
 
 # Default directory used to store the feed file and fetched images
-cachedir="${XDG_CACHE_HOME:-$HOME/.cache}/redyt"
+cachedir="/tmp/redyt"
 
 # If cachedir does not exist, create it
 if [ ! -d "$cachedir" ]; then

--- a/redyt
+++ b/redyt
@@ -8,7 +8,7 @@ done
 [ ! "$(which notify-send)" ] && notifier="echo" || notifier="notify-send"
 
 # Default config directory
-configdir="${XDG_CONFIG_HOME:-$HOME/.config}/redyt"
+configdir="/tmp/redyt"
 
 # Create .config/redyt if it does not exist to prevent
 # the program from not functioning properly


### PR DESCRIPTION
@AlexBocken accidentally moved the config directory to /tmp/redyt instead of moving the cache directory to said location.